### PR TITLE
Fix "changed" filter in latest Ansible versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,14 +21,14 @@
 - name: Check sysctl command capabilities
   shell: sysctl --help | grep -E '^\s+\-\-system\s+' || true
   register: sysctl__register_system
-  when: sysctl__register_config|changed
+  when: sysctl__register_config is changed
   check_mode: False
 
 - name: Apply kernel parameters if they were modified
   command: '{{ "sysctl --system"
                if (sysctl__register_system.stdout != "")
                else ("sysctl -e -p " + sysctl__config_file) }}'
-  when: sysctl__register_config|changed
+  when: sysctl__register_config is changed
 
 - name: Post hooks
   include: '{{ lookup("task_src", "sysctl/post_main.yml") }}'


### PR DESCRIPTION
`x|changed` has been changed in favor to `x is changed` since Ansible
2.5: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters